### PR TITLE
Fix key not found: sheetXX error

### DIFF
--- a/src/xlsx/utils.nim
+++ b/src/xlsx/utils.nim
@@ -980,7 +980,7 @@ proc parseSheetFileNames(contentTypes: ContentTypes, workbook: WorkBook): Table[
   result = collect(initTable(workbook.data.len)):
     for sheetName, rId in workbook.data.pairs:
       let
-        internalSheetName = workbookRels[rId]
+        internalSheetName = workbookRels[rId].splitFile.name
         sheetFileName = contentTypes[internalSheetName]
 
       {sheetName: sheetFileName}

--- a/src/xlsx/utils.nim
+++ b/src/xlsx/utils.nim
@@ -1,5 +1,6 @@
 import os, streams, parsexml, parseutils, tables, times, strutils
 import format
+import sugar
 
 import zip / zipfiles
 
@@ -27,6 +28,7 @@ type
     data: Table[string, string]
     date1904: bool
   ContentTypes = Table[string, string]
+  Relationships = Table[string, string]
   SharedStrings = seq[string]
   Styles = seq[string]
 
@@ -159,6 +161,51 @@ proc parseContentTypes(fileName: string): ContentTypes {.inline.} =
   let workBookKey = "workbook"
   if workBookKey notin result or result[workBookKey] == "":
     result[workBookKey] = DEFAULT_WORKBOOK_PATH
+
+proc parseRelationship(x: var XmlParser, res: var Relationships) {.inline.} =
+  var
+    id: string
+    target: string
+
+  while true:
+    x.next()
+    case x.kind
+    of xmlAttribute:
+      # match attr Id
+      if x.attrKey =?= "Id":
+        id = x.attrValue
+      # match attr Target
+      if x.attrKey =?= "Target":
+        target = x.attrValue
+    of xmlElementEnd:
+      break
+    else:
+      discard
+
+  res[id] = target
+
+proc parseRelationships(fileName: string): Relationships {.inline.} =
+  var s = newFileStream(fileName, fmRead)
+  if s == nil: quit("Unable to read file: " & fileName)
+  var x: XmlParser
+  open(x, s, fileName)
+  defer: x.close()
+
+  let name = parseNameSpace(x)
+
+  while true:
+    case x.kind
+    of xmlElementOpen:
+      # catch <namespace:Relationship
+      if x.elementName =?= (name & "Relationship"):
+        x.parseRelationship(result)
+    of xmlElementEnd:
+      discard
+    of xmlEof:
+      break
+    else:
+      discard
+    x.next()
 
 proc parseTData(x: var XmlParser, res: var seq[string], escapeStrings: bool,
     count: var int) {.inline.} =
@@ -372,8 +419,8 @@ proc parseSheetNameInWorkBook(x: var XmlParser, nameSpace: string): Table[
         # parse name -> "Sheet1"
         if x.attrKey =?= "name":
           name = x.attrValue
-        # parse sheetId -> "s1"
-        if x.attrKey =?= "sheetId":
+        # parse r:id -> "rId1"
+        if x.attrKey =?= "r:id":
           result[name] = x.attrValue
       of xmlElementEnd:
         break
@@ -921,6 +968,23 @@ proc parseAllSheetName*(fileName: string): seq[string] {.inline.} =
   for key in workbook.data.keys:
     result.add(key)
 
+proc getRelsFileName(fileName: string): string =
+  let pathParts = fileName.splitPath
+  result = pathParts.head / "_rels" / pathParts.tail & ".rels"
+
+proc parseSheetFileNames(contentTypes: ContentTypes, workbook: WorkBook): Table[string, string] =
+  let
+    workbookFileName = TempDir / contentTypes["workbook"]
+    workbookRels = parseRelationships(workbookFileName.getRelsFileName)
+
+  result = collect(initTable(workbook.data.len)):
+    for sheetName, rId in workbook.data.pairs:
+      let
+        internalSheetName = workbookRels[rId]
+        sheetFileName = contentTypes[internalSheetName]
+
+      {sheetName: sheetFileName}
+
 proc parseExcel*(fileName: string, sheetName = "", header = false,
     skipHeaders = false, escapeStrings = false, trailingRows = false): SheetTable =
   ## Parse excel and return SheetTable which contains
@@ -942,6 +1006,7 @@ proc parseExcel*(fileName: string, sheetName = "", header = false,
     contentTypes = parseContentTypes(TempDir / "[Content_Types].xml")
     workbook = parseWorkBook(TempDir / contentTypes["workbook"])
     styles = parseStyles(TempDir / contentTypes["styles"])
+    sheetFileNames = parseSheetFileNames(contentTypes, workbook)
 
   var sharedString: SharedStrings
   if "sharedStrings" in contentTypes:
@@ -949,19 +1014,17 @@ proc parseExcel*(fileName: string, sheetName = "", header = false,
         escapeStrings = escapeStrings)
 
   if sheetName == "":
-    for key, value in workbook.data.pairs:
-      var sheet = parseSheet(TempDir / contentTypes["sheet" & $value], styles,
+    for name, fileName in sheetFileNames.pairs:
+      var sheet = parseSheet(TempDir / fileName, styles,
           workbook.date1904, trailingRows)
-      result.data[key] = getSheetArray(sheet, sharedString, header, skipHeaders)
+      result.data[name] = getSheetArray(sheet, sharedString, header, skipHeaders)
     return
 
-  if sheetName notin workbook.data:
+  if sheetName notin sheetFileNames:
     raise newException(NotFoundSheetError, "no such sheet name: " & sheetName)
 
-  let
-    value = workbook.data[sheetName]
   var
-    sheet = parseSheet(TempDir / contentTypes["sheet" & $value], styles,
+    sheet = parseSheet(TempDir / sheetFileNames[sheetName], styles,
         workbook.date1904, trailingRows)
   result.data[sheetName] = getSheetArray(sheet, sharedString, header, skipHeaders)
 
@@ -977,19 +1040,18 @@ iterator lines*(fileName: string, sheetName: string,
     contentTypes = parseContentTypes(TempDir / "[Content_Types].xml")
     workbook = parseWorkBook(TempDir / contentTypes["workbook"])
     styles = parseStyles(TempDir / contentTypes["styles"])
+    sheetFileNames = parseSheetFileNames(contentTypes, workbook)
 
   var sharedString: SharedStrings
   if "sharedStrings" in contentTypes:
     sharedString = parseSharedString(TempDir / contentTypes["sharedStrings"],
         escapeStrings = escapeStrings)
 
-  if sheetName notin workbook.data:
+  if sheetName notin sheetFileNames:
     raise newException(NotFoundSheetError, "no such sheet name: " & sheetName)
 
-  let
-    value = workbook.data[sheetName]
   var
-    sheet = parseSheet(TempDir / contentTypes["sheet" & $value], styles,
+    sheet = parseSheet(TempDir / sheetFileNames[sheetName], styles,
         workbook.date1904)
   for item in get(sheet, sharedString):
     if skipEmptyLines and len(item) == 0:
@@ -1246,18 +1308,18 @@ proc readExcel*[T: SomeNumber|bool|string](fileName: string,
     contentTypes = parseContentTypes(TempDir / "[Content_Types].xml")
     workbook = parseWorkBook(TempDir / contentTypes["workbook"])
     styles = parseStyles(TempDir / contentTypes["styles"])
+    sheetFileNames = parseSheetFileNames(contentTypes, workbook)
 
   var sharedString: SharedStrings
   if "sharedStrings" in contentTypes:
     sharedString = parseSharedString(TempDir / contentTypes["sharedStrings"],
         escapeStrings = escapeStrings)
 
-  if sheetName notin workbook.data:
+  if sheetName notin sheetFileNames:
     raise newException(NotFoundSheetError, "no such sheet name: " & sheetName)
 
   let
-    value = workbook.data[sheetName]
-    sheet = parseSheet(TempDir / contentTypes["sheet" & $value], styles,
+    sheet = parseSheet(TempDir / sheetFileNames[sheetName], styles,
         workbook.date1904)
 
   result = getSheetTensor[T](sheet, sharedString, skipHeaders)

--- a/src/xlsx/utils.nim
+++ b/src/xlsx/utils.nim
@@ -969,8 +969,8 @@ proc parseAllSheetName*(fileName: string): seq[string] {.inline.} =
     result.add(key)
 
 proc getRelsFileName(fileName: string): string =
-  let pathParts = fileName.splitPath
-  result = pathParts.head / "_rels" / pathParts.tail & ".rels"
+  let pathParts = fileName.splitFile
+  result = pathParts.dir / "_rels" / pathParts.name & pathParts.ext & ".rels"
 
 proc parseSheetFileNames(contentTypes: ContentTypes, workbook: WorkBook): Table[string, string] =
   let

--- a/src/xlsx/utils.nim
+++ b/src/xlsx/utils.nim
@@ -163,9 +163,7 @@ proc parseContentTypes(fileName: string): ContentTypes {.inline.} =
     result[workBookKey] = DEFAULT_WORKBOOK_PATH
 
 proc parseRelationship(x: var XmlParser, res: var Relationships) {.inline.} =
-  var
-    id: string
-    target: string
+  var id, target: string
 
   while true:
     x.next()
@@ -970,6 +968,7 @@ proc parseAllSheetName*(fileName: string): seq[string] {.inline.} =
 
 proc getRelsFileName(fileName: string): string =
   let pathParts = fileName.splitFile
+  # Valid even when name and ext are empty (i.e. /_rels/.rels)
   result = pathParts.dir / "_rels" / pathParts.name & pathParts.ext & ".rels"
 
 proc parseSheetFileNames(contentTypes: ContentTypes, workbook: WorkBook): Table[string, string] =

--- a/tests/test_parse_excel.nim
+++ b/tests/test_parse_excel.nim
@@ -4,7 +4,7 @@ import xlsx
 
 
 suite "Test parse Excel":
-  let sheetName = "Sheet2"
+  let sheetName = "Sheet1"
 
   test "Parse Excel":
     let data = parseExcel("tests/test.xlsx")
@@ -21,5 +21,5 @@ suite "Test parse Excel":
     check(data == @["Sheet1", "Sheet2"])
 
   test "Read Excel by lines":
-    for line in lines("tests/test.xlsx", "Sheet2"):
+    for line in lines("tests/test.xlsx", "Sheet1"):
       discard line

--- a/tests/test_sheet_array.nim
+++ b/tests/test_sheet_array.nim
@@ -3,7 +3,7 @@ import unittest
 import xlsx
 
 suite "Test SheetArray":
-  let sheetName = "Sheet2"
+  let sheetName = "Sheet1"
 
   test "Get one element from SheetArray":
     let data = parseExcel("tests/test.xlsx")

--- a/xlsx.nimble
+++ b/xlsx.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.4.4"
+version       = "0.4.5"
 author        = "flywind"
 description   = "Read and parse Excel files"
 license       = "MIT"


### PR DESCRIPTION
Issue: https://github.com/xflywind/xlsx/issues/6
Use rels files to find valid internal sheet names as per [suggest](https://github.com/xflywind/xlsx/issues/6#issuecomment-790763303) from artemklevtsov

Some tests actually were bugged, as the sheet with data in test.xlsx is "Sheet1", not "Sheet2". The tests were green due to messed up internal sheet names: the data from Sheet1 is inside xl/worksheets/sheet2.xml file

